### PR TITLE
Update q003.md

### DIFF
--- a/question/q003.md
+++ b/question/q003.md
@@ -15,12 +15,12 @@
 ```
 func reverString(s string) (string, bool) {
     str := []rune(s)
-    len := len(str)
+    l := len(str)
     if len > 5000 {
-        return string(str), false
+        return s, false
     }
     for i := 0; i < len/2; i++ {
-        str[i], str[len-1-i] = str[len-1-i], str[i]
+        str[i], str[l-1-i] = str[l-1-i], str[i]
     }
     return string(str), true
 }


### PR DESCRIPTION
- 大于5000返回时，可以直接返回s，不需要将rune再转换一次；
- 计算len时，变量最好不使用关键字len；