### PR TITLE
Update q002.md

### DIFF
--- a/question/q002.md
+++ b/question/q002.md
@@ -43,11 +43,11 @@ func isUniqueString2(s string) bool {
 	if strings.Count(s,"") > 3000{
 		return  false
 	}
-	for _,v := range s {
+	for k,v := range s {
 		if v > 127 {
 			return false
 		}
-		if strings.Index(s,string(v)) != strings.LastIndex(s,string(v)) {
+		if strings.Index(s,string(v)) != k {
 			return false
 		}
 	}


### PR DESCRIPTION
`strings.Index`找到的位置可以和当前字符的k位置比较，如果有相同字符，必然有一个字符的k和Index不一致，去掉LastIndex之后可以减少比较次数，提高性能。