### PR TITLE
Bugfix: solve waitTimeout goroutine leak

### DIFF
--- a/question/q013.md
+++ b/question/q013.md
@@ -78,7 +78,7 @@ func WaitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	// 要求sync.WaitGroup支持timeout功能
 	// 如果timeout到了超时时间返回true
 	// 如果WaitGroup自然结束返回false
-	ch := make(chan bool)
+	ch := make(chan bool, 1)
 
 	go time.AfterFunc(timeout, func() {
 		ch <- true

--- a/src/q013.go
+++ b/src/q013.go
@@ -30,7 +30,7 @@ func WaitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	// 要求sync.WaitGroup支持timeout功能
 	// 如果timeout到了超时时间返回true
 	// 如果WaitGroup自然结束返回false
-	ch := make(chan bool)
+	ch := make(chan bool, 1)
 
 	go time.AfterFunc(timeout, func() {
 		ch <- true


### PR DESCRIPTION
如果采取没有缓冲的channel, 会导致WaitTimeout返回后，WaitTimeout函数体中仍然有goroutine在等待channel。